### PR TITLE
added pipeline to automatically generate the API documentation

### DIFF
--- a/.github/workflows/build_documentation_and_deploy-workflow.yml
+++ b/.github/workflows/build_documentation_and_deploy-workflow.yml
@@ -1,0 +1,109 @@
+name: Documentation Build Pipeline - Development
+
+on:
+  push:
+    branches:
+      - development
+
+jobs:
+  build-and-generate-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Setup SSH
+      uses: webfactory/ssh-agent@v0.5.3
+      with:
+        ssh-private-key: ${{ secrets.SSH_DOCUMENTATION_KEY }}
+
+    - name: Checkout "reach-c-stack"
+      uses: actions/checkout@v3
+      with:
+        path: reach-c-stack
+
+    - name: Clone Repository "reach-documentation"
+      run: |
+        git clone git@github.com:cygnus-technology/reach-documentation.git reach-documentation
+      working-directory: ${{ github.workspace }}
+
+    - name: Install prerequisites
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential curl libssl-dev libbz2-dev libreadline-dev \
+        libsqlite3-dev libffi-dev zlib1g-dev liblzma-dev libncurses5-dev \
+        libncursesw5-dev xz-utils tk-dev libdb-dev libgdbm-dev \
+        libsqlite3-dev openssl libbz2-dev libreadline-dev doxygen
+      working-directory: reach-c-stack
+
+    - name: Check for Doxygen installation
+      run: |
+        if ! command -v doxygen &> /dev/null; then
+          echo "Doxygen is not installed."
+          sudo apt-get install -y doxygen
+        fi
+        echo "Doxygen is installed."
+      working-directory: reach-c-stack
+
+    - name: Install pyenv
+      run: |
+        if ! command -v pyenv &> /dev/null; then
+          curl -L https://pyenv.run | bash
+          echo 'export PATH="$HOME/.pyenv/bin:$PATH"' >> $GITHUB_ENV
+          echo 'eval "$(pyenv init --path)"' >> $GITHUB_ENV
+          echo 'eval "$(pyenv virtualenv-init -)"' >> $GITHUB_ENV
+        fi
+        echo "pyenv is installed."
+      working-directory: reach-c-stack
+
+    - name: Set local Python version
+      run: |
+        if [ -f ".python-version" ]; then
+          pythonVersion=$(cat .python-version)
+          pyenv install $pythonVersion
+          pyenv local $pythonVersion
+        else
+          echo ".python-version file not found."
+          exit 1
+        fi
+      working-directory: reach-c-stack/docs
+
+    - name: Create and activate virtual environment
+      run: |
+        if [ ! -d "__venv" ]; then
+          python -m venv __venv
+        fi
+        source __venv/bin/activate
+      working-directory: reach-c-stack/docs
+
+    - name: Ensure package versions
+      run: |
+        pip list --format=freeze
+        while IFS== read -r package version; do
+          pip install "$package==$version"
+        done < "requirements.txt"
+      working-directory: reach-c-stack/docs
+
+    - name: Generate documentation
+      run: |
+        doxygen ./reach.doxyfile.in > doxygen_build.log 2> doxygen_error.log
+        sphinx-build -b html ./__source ./__build > sphinx_build.log 2> sphinx_error.log
+        echo "Documentation generation complete."
+      working-directory: reach-c-stack/docs
+
+    - name: Setup Git configuration
+      run: |
+        git config --global user.name "Developer-i3PD"
+        git config --global user.email "Developer@i3pd.com"
+
+    - name: Copy documentation to "reach-documentation"
+      run: |
+        cp -R __build/* ../reach-documentation
+      working-directory: reach-c-stack/docs
+
+    - name: Commit and push changes to "reach-documentation""
+      run: |
+        git add .
+        git commit -m "Update documentation"
+        git push origin main
+      working-directory: reach-documentation
+      env:
+        GIT_SSH_COMMAND: ssh -v

--- a/docs/setup_docs_venv.sh
+++ b/docs/setup_docs_venv.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+# Author: Peter S. Jamrozinski
+# Organization: i3 Product Development
+# Email: Peter.Jamrozinski@i3pd.com
+
 # Initialize a variable to hold the auto-decision flag (-Y or -N), empty means no decision made
-AUTO_DECISION=""
+AUTO_DECISION="-Y"
 SILENT_MODE=""
 
 check_prerequisites() {


### PR DESCRIPTION
This PR adds a pipeline that replicates the actions of setup_docs_venv.sh by building the documentation __build directory and pushing the artifacts to the reach-documentation repository.